### PR TITLE
Add check for fonts to contain all characters from character list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ beautifulsoup4>=4.6.0
 diffimg==0.2.3
 arabic-reshaper==2.1.3
 python-bidi==0.4.2
+fonttools>=4.33.2

--- a/trdg/run.py
+++ b/trdg/run.py
@@ -11,6 +11,7 @@ import sys
 from collections import deque
 from multiprocessing import Pool
 
+from fontTools.ttLib import TTFont
 from tqdm import tqdm
 
 from trdg.data_generator import FakeTextDataGenerator
@@ -422,6 +423,17 @@ def main():
             sys.exit("Cannot open font")
     else:
         fonts = load_fonts(args.language)
+
+    # Remove fonts that miss any characters from specified list
+    if args.from_characters:
+        fonts_list = fonts.copy()
+        for font in fonts_list:
+            ttfont = TTFont(font)
+            cmap_keys = set()
+            for table in ttfont['cmap'].tables:
+                cmap_keys.update(table.cmap.keys())
+            if not set(map(ord, args.from_characters)).issubset(cmap_keys):
+                fonts.remove(font)
 
     # Creating synthetic sentences (or word)
     strings = []


### PR DESCRIPTION
Solved problem of generating images with blank symbols if text is generated with wrong font. If any symbols from character list are not in the font character map, this font is being removed from fonts list before generation